### PR TITLE
Changes after users rollout

### DIFF
--- a/db/migrate/20200411193333_change_campaigns_user_id_to_not_null.rb
+++ b/db/migrate/20200411193333_change_campaigns_user_id_to_not_null.rb
@@ -1,0 +1,5 @@
+class ChangeCampaignsUserIdToNotNull < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :campaigns, :user_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_04_171951) do
+ActiveRecord::Schema.define(version: 2020_04_11_193333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2020_04_04_171951) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "current_map_id"
-    t.uuid "user_id"
+    t.uuid "user_id", null: false
     t.index ["current_map_id"], name: "index_campaigns_on_current_map_id"
     t.index ["user_id"], name: "index_campaigns_on_user_id"
   end

--- a/lib/tasks/dev/prime.rake
+++ b/lib/tasks/dev/prime.rake
@@ -10,17 +10,10 @@ namespace :dev do
       dm.save
     end
 
-    campaign = Campaign.find_by(
-      name: "Dragon of Icespire Peak"
+    campaign = Campaign.find_or_create_by(
+      name: "Dragon of Icespire Peak",
+      user: dm
     )
-    if campaign
-      campaign.update(user: dm)
-    else
-      campaign = Campaign.find_or_create_by(
-        name: "Dragon of Icespire Peak",
-        user: dm
-      )
-    end
 
     [
       {


### PR DESCRIPTION
Closes #32

After users are deployed to production:

- Adds not null to `user_id` on campaign
- Changes `dev:prime` to specify user on Campaign more simply

https://github.com/jdbann/table/pull/19/files#r403466665