### PR TITLE
Only allow DM to modify campaign/map

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,4 +1,20 @@
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
+    protected
+
+    def render_partial(partial, options = {})
+      ActionController::Renderer::RACK_KEY_TRANSLATION[:clearance] ||=
+        :clearance
+      clearance_session = Clearance::Session.new({}).tap do |session|
+        session.sign_in(current_user)
+      end
+      ApplicationController.renderer.new(clearance: clearance_session).render(
+        options.merge(partial: partial)
+      )
+    end
+
+    def dm?(campaign)
+      campaign.user == current_user
+    end
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,9 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = @env[:clearance].current_user
+    end
   end
 end

--- a/app/channels/campaign_channel.rb
+++ b/app/channels/campaign_channel.rb
@@ -7,7 +7,7 @@ class CampaignChannel < ApplicationCable::Channel
   def change_current_map(data)
     campaign = Campaign.find(data["campaign_id"])
     map = campaign.maps.find(data["map_id"])
-    return if campaign.current_map == map
+    return if !dm?(campaign) || campaign.current_map == map
 
     campaign.update(current_map: map)
     broadcast_to(
@@ -19,9 +19,6 @@ class CampaignChannel < ApplicationCable::Channel
   private
 
   def render_current_map(campaign)
-    ApplicationController.renderer.render(
-      partial: "campaigns/current_map",
-      locals: { campaign: campaign }
-    )
+    render_partial("campaigns/current_map", locals: { campaign: campaign })
   end
 end

--- a/app/channels/map_channel.rb
+++ b/app/channels/map_channel.rb
@@ -6,7 +6,7 @@ class MapChannel < ApplicationCable::Channel
 
   def move_map(data)
     map = Map.find(data["map_id"])
-    return if map.x == data["x"] && map.y == data["y"]
+    return if !dm?(map.campaign) || map.x == data["x"] && map.y == data["y"]
 
     if map.update(x: data["x"], y: data["y"])
       broadcast_to(
@@ -22,7 +22,7 @@ class MapChannel < ApplicationCable::Channel
 
   def set_zoom(data)
     map = Map.find(data["map_id"])
-    return if map.zoom == data["zoom"]
+    return if !dm?(map.campaign) || map.zoom == data["zoom"]
 
     if map.update(zoom: data["zoom"])
       broadcast_to(

--- a/app/helpers/campaigns_helper.rb
+++ b/app/helpers/campaigns_helper.rb
@@ -1,0 +1,7 @@
+module CampaignsHelper
+  def dm?(campaign, output = nil)
+    if signed_in? && campaign.user == current_user
+      output.presence || true
+    end
+  end
+end

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -154,9 +154,11 @@ export default class extends Controller {
   }
 
   updateZoomButtons() {
-    const zoom = parseInt(this.imageTarget.dataset.zoom)
-    this.zoomOutTarget.disabled = (zoom === 0)
-    this.zoomInTarget.disabled = (zoom === parseInt(this.imageTarget.dataset.zoomMax))
+    if (this.hasZoomOutTarget && this.hasZoomInTarget) {
+      const zoom = parseInt(this.imageTarget.dataset.zoom)
+      this.zoomOutTarget.disabled = (zoom === 0)
+      this.zoomInTarget.disabled = (zoom === parseInt(this.imageTarget.dataset.zoomMax))
+    }
   }
 
   cableReceived(data) {

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -7,7 +7,7 @@
       controller: "map css-var",
       "map-id": campaign.current_map.id,
       target: "map.image",
-      action: "mousedown->map#moveMap",
+      action: dm?(campaign, "mousedown->map#moveMap"),
       x: campaign.current_map.x,
       y: campaign.current_map.y,
       zoom: campaign.current_map.zoom,
@@ -21,14 +21,16 @@
     <div class="current-map__token-container" data-target="map.tokenContainer">
       <%= render campaign.current_map.tokens %>
     </div>
-    <div class="controls w-16 absolute top-0 right-0 m-2 flex justify-center">
-      <%= button_tag class: "flex-1 text-center border rounded-l-md h-7 bg-gray-200 cursor-default", data: { target: "map.zoomOut", action: "click->map#zoomOut" } do %>
-        -
-      <% end %>
-      <%= button_tag class: "flex-1 text-center border rounded-r-md h-7 bg-gray-200 cursor-default", data: { target: "map.zoomIn", action: "click->map#zoomIn" } do %>
-        +
-      <% end %>
-    </div>
+    <% if dm?(campaign) %>
+      <div class="controls w-16 absolute top-0 right-0 m-2 flex justify-center">
+        <%= button_tag class: "flex-1 text-center border rounded-l-md h-7 bg-gray-200 cursor-default", data: { target: "map.zoomOut", action: "click->map#zoomOut" } do %>
+          -
+        <% end %>
+        <%= button_tag class: "flex-1 text-center border rounded-r-md h-7 bg-gray-200 cursor-default", data: { target: "map.zoomIn", action: "click->map#zoomIn" } do %>
+          +
+        <% end %>
+      </div>
+    <% end %>
   <% end %>
 <% else %>
   <h2>No Current Map</h2>

--- a/app/views/campaigns/_map_selector.html.erb
+++ b/app/views/campaigns/_map_selector.html.erb
@@ -1,0 +1,19 @@
+<div class="map-selector">
+  <% campaign.maps.each do |map| %>
+    <div class="map-selector__option">
+      <%= content_tag :div, nil, class: "map-selector__option-background", style: "background-image: url('#{url_for map.image}')" %>
+      <%= content_tag :div, class: "map-selector__option-overlay", data: {
+        action: "click->campaign#chooseMapOption",
+        map_id: map.id
+      } do %>
+        <%= content_tag :span, map.name, class: "map-selector__option-text" %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= link_to new_campaign_map_path(campaign), class: "map-selector__option map-selector__new" do %>
+    <div class="absolute">
+      <span class="">New Map</span>
+    </div>
+  <% end %>
+</div>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -3,22 +3,9 @@
 <hr class="my-2" />
 
 <%= content_tag :div, class: "relative", data: { controller: "campaign", "campaign-id": campaign.id } do %>
-  <div class="map-selector">
-    <% campaign.maps.each do |map| %>
-      <div class="map-selector__option">
-        <%= content_tag :div, nil, class: "map-selector__option-background", style: "background-image: url('#{url_for map.image}')" %>
-        <%= content_tag :div, class: "map-selector__option-overlay", data: { action: "click->campaign#chooseMapOption",  map_id: map.id } do %>
-          <%= content_tag :span, map.name, class: "map-selector__option-text" %>
-        <% end %>
-      </div>
-    <% end %>
-
-    <%= link_to new_campaign_map_path(campaign), class: "map-selector__option map-selector__new" do %>
-      <div class="absolute">
-        <span class="">New Map</span>
-      </div>
-    <% end %>
-  </div>
+  <% if dm?(campaign) %>
+    <%= render "map_selector", campaign: campaign %>
+  <% end %>
 
   <div data-target="campaign.currentMap">
     <%= render partial: "current_map", locals: { campaign: campaign } %>

--- a/spec/support/map.rb
+++ b/spec/support/map.rb
@@ -1,0 +1,5 @@
+def have_map_with_data(map, attribute, value)
+  have_css(
+    ".current-map[data-map-id='#{map.id}'][data-#{attribute}='#{value}']"
+  )
+end

--- a/spec/support/system_test.rb
+++ b/spec/support/system_test.rb
@@ -3,3 +3,7 @@ RSpec.configure do |config|
     driven_by :selenium_chrome_headless
   end
 end
+
+def wait_for_connection
+  page.has_no_css?("[data-target='campaign.statusIndicator']")
+end

--- a/spec/system/manage_maps_spec.rb
+++ b/spec/system/manage_maps_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "manage maps", type: :system do
   it "lists maps" do
     campaign = create :campaign
     create :map, campaign: campaign, name: "Dwarven Excavation"
-    visit campaign_path(campaign)
+    visit campaign_path(campaign, as: campaign.user)
     expect(page).to have_content "Dwarven Excavation"
   end
 
@@ -38,7 +38,7 @@ RSpec.describe "manage maps", type: :system do
     campaign = create :campaign
     create :map, campaign: campaign, name: "Dwarven Excavation"
     create :map, campaign: campaign, name: "Gnomengarde"
-    visit campaign_path(campaign)
+    visit campaign_path(campaign, as: campaign.user)
     expect(page).to have_css "h2", text: "No Current Map"
     find(".map-selector__option", text: "Dwarven Excavation").click
     expect(page).to have_css "h2", text: "Dwarven Excavation"
@@ -49,7 +49,7 @@ RSpec.describe "manage maps", type: :system do
   it "moves the map" do
     campaign = create :campaign
     map = create :map, campaign: campaign, name: "Dwarven Excavation", zoom: 0
-    visit campaign_path(campaign)
+    visit campaign_path(campaign, as: campaign.user)
     find(".map-selector__option", text: "Dwarven Excavation").click
     click_and_move_map(map, from: { x: 300, y: 300 }, to: { x: 50, y: 50 })
 
@@ -60,7 +60,7 @@ RSpec.describe "manage maps", type: :system do
   it "moves the map for other users" do
     campaign = create :campaign
     map = create :map, campaign: campaign, name: "Dwarven Excavation", zoom: 0
-    visit campaign_path(campaign)
+    visit campaign_path(campaign, as: campaign.user)
     find(".map-selector__option", text: "Dwarven Excavation").click
 
     using_session "other user" do
@@ -80,7 +80,7 @@ RSpec.describe "manage maps", type: :system do
     map = create :map, campaign: campaign, name: "Dwarven Excavation", zoom: 0
     map.center_image
 
-    visit campaign_path(campaign)
+    visit campaign_path(campaign, as: campaign.user)
     find(".map-selector__option", text: "Dwarven Excavation").click
 
     expect(page).to have_map_with_data(map, "width", "100")
@@ -98,7 +98,7 @@ RSpec.describe "manage maps", type: :system do
     map = create :map, campaign: campaign, name: "Dwarven Excavation", zoom: 0
     map.center_image
 
-    visit campaign_path(campaign)
+    visit campaign_path(campaign, as: campaign.user)
     find(".map-selector__option", text: "Dwarven Excavation").click
     using_session "other user" do
       visit campaign_path(campaign)
@@ -121,10 +121,9 @@ RSpec.describe "manage maps", type: :system do
     create :map, campaign: campaign, name: "Dwarven Excavation"
     create :map, campaign: campaign, name: "Gnomengarde"
 
-    visit campaign_path(campaign)
+    visit campaign_path(campaign, as: campaign.user)
     using_session "other user" do
       visit campaign_path(campaign)
-      wait_for_connection
       expect(page).to have_css "h2", text: "No Current Map"
     end
 
@@ -137,15 +136,5 @@ RSpec.describe "manage maps", type: :system do
     using_session "other user" do
       expect(page).to have_css "h2", text: "Gnomengarde"
     end
-  end
-
-  def wait_for_connection
-    page.has_no_css?("[data-target='campaign.statusIndicator']")
-  end
-
-  def have_map_with_data(map, attribute, value)
-    have_css(
-      ".current-map[data-map-id='#{map.id}'][data-#{attribute}='#{value}']"
-    )
   end
 end

--- a/spec/system/move_tokens_spec.rb
+++ b/spec/system/move_tokens_spec.rb
@@ -4,17 +4,19 @@ RSpec.describe "move tokens", type: :system do
   it "shows tokens on the map" do
     map = create :map
     token = create :token, map: map
-    visit campaign_path(map.campaign)
+    visit campaign_path(map.campaign, as: map.campaign.user)
+    wait_for_connection
     find(".map-selector__option", text: map.name).click
     expect(page).to have_token_with_data(token, "token-id", token.id)
   end
 
   it "drags tokens" do
     map = create :map, zoom: 2
+    map.campaign.update(current_map: map)
     token = create :token, map: map, x: 0, y: 0
-    visit campaign_path(map.campaign)
-    find(".map-selector__option", text: map.name).click
 
+    visit campaign_path(map.campaign)
+    wait_for_connection
     click_and_move_token(token, by: { x: 50, y: 50 })
 
     expect(page).to have_token_with_data(token, "x", 50)
@@ -23,10 +25,11 @@ RSpec.describe "move tokens", type: :system do
 
   it "factors in map zoom when dragging" do
     map = create :map, zoom: 0
+    map.campaign.update(current_map: map)
     token = create :token, map: map, x: 0, y: 0
-    visit campaign_path(map.campaign)
-    find(".map-selector__option", text: map.name).click
 
+    visit campaign_path(map.campaign)
+    wait_for_connection
     click_and_move_token(token, by: { x: 50, y: 50 })
 
     expect(page).to have_token_with_data(token, "x", 200)
@@ -35,12 +38,14 @@ RSpec.describe "move tokens", type: :system do
 
   it "moves the token for other users" do
     map = create :map, zoom: 2
+    map.campaign.update(current_map: map)
     token = create :token, map: map, x: 0, y: 0
-    visit campaign_path(map.campaign)
-    find(".map-selector__option", text: map.name).click
 
+    visit campaign_path(map.campaign)
+    wait_for_connection
     using_session "other user" do
       visit campaign_path(map.campaign)
+      wait_for_connection
     end
 
     click_and_move_token(token, by: { x: 50, y: 50 })

--- a/spec/system/visitor_views_map_spec.rb
+++ b/spec/system/visitor_views_map_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Visitor viewing a map", type: :system do
+  it "cannot zoom the map" do
+    map = create :map, name: "Dwarven Excavation"
+    map.campaign.update(current_map: map)
+
+    visit campaign_path(map.campaign)
+
+    expect(page).not_to have_button("-")
+    expect(page).not_to have_button("+")
+  end
+
+  it "cannot move the map" do
+    map = create :map, name: "Dwarven Excavation"
+    map.campaign.update(current_map: map)
+
+    visit campaign_path(map.campaign)
+    click_and_move_map(map, from: { x: 300, y: 300 }, to: { x: 50, y: 50 })
+
+    expect(page).to have_map_with_data(map, "x", "50")
+    expect(page).to have_map_with_data(map, "y", "50")
+  end
+
+  it "does not see option to create new maps" do
+    campaign = create :campaign
+    create :map, campaign: campaign, name: "Dwarven Excavation"
+    visit campaign_path(campaign)
+    expect(page).not_to have_content "New Map"
+  end
+end


### PR DESCRIPTION
Fixes #15 and #12

This change restricts changing the map, moving the map, and zooming the map
to the dm (the person who created the campaign).

These protections are in the UI (either by removing elements or stimulus
actions) as well as the ActionCable channels.

A new `render_partial` helper is introduced for use in Channels. This helper is used for rendering partials and ensuring that `current_user` is set, along with other clearance provided helpers like `signed_in?`.