### PR TITLE
Ensure container has horizontal padding

### DIFF
--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -1,5 +1,5 @@
 <div class="bg-gray-200">
-  <%= content_tag :div, class: "py-4 #{full_width ? "mx-4" : "mx-auto container"}" do %>
+  <%= content_tag :div, class: "py-4 #{full_width ? "mx-4" : "mx-auto container px-8"}" do %>
     <div class="flex items-baseline">
       <%= link_to root_path, class: "flex-1" do %>
         <span class="text-2xl">Table</span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 
   <body>
     <%= render partial: "header", locals: { full_width: false } %>
-    <div class="container mx-auto py-4">
+    <div class="container mx-auto px-8 py-4">
       <%= render "flashes" %>
 
       <%= yield %>


### PR DESCRIPTION
Fixes #37. As documented at https://tailwindcss.com/docs/container/

> Tailwind's container does not center itself automatically and does not
> have any built-in horizontal padding.

As included on that page, we need to manually add horizontal padding,
which is what this change does.