### PR TITLE
Move tokens in and out of token drawer

### DIFF
--- a/app/channels/map_channel.rb
+++ b/app/channels/map_channel.rb
@@ -57,6 +57,31 @@ class MapChannel < ApplicationCable::Channel
     )
   end
 
+  def stash_token(data)
+    map = Map.find(data["map_id"])
+    token = map.tokens.find(data["token_id"])
+    return if !dm?(map.campaign)
+
+    token.update(stashed: true)
+    broadcast_to(
+      map,
+      {
+        operation: "stashToken",
+        token_id: token.id,
+        stashed: true
+      }
+    )
+  end
+
+  def place_token(data)
+    map = Map.find(data["map_id"])
+    token = map.tokens.find(data["token_id"])
+    return if !dm?(map.campaign)
+
+    token.update(stashed: false)
+    MapChannel.add_token(token)
+  end
+
   class << self
     def add_token(token)
       broadcast_to(

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -99,34 +99,33 @@ export default class extends Controller {
     )
   }
 
+  stopPropagation(event) {
+    event.stopPropagation()
+  }
+
   startMoveToken(event) {
     event.stopPropagation()
+
     const { screenX, screenY, target } = event
+
     target.dataset.originalX = target.dataset.x
     target.dataset.originalY = target.dataset.y
     target.dataset.dragStartX = screenX
     target.dataset.dragStartY = screenY
     target.dataset.beingDragged = true
-
-    const moveToken = this.buildMoveToken(target).bind(this)
-
-    document.addEventListener("mousemove", moveToken)
-    document.addEventListener("mouseup", () => {
-      document.removeEventListener("mousemove", moveToken)
-      delete target.dataset.originalX
-      delete target.dataset.originalY
-      delete target.dataset.dragStartX
-      delete target.dataset.dragStartY
-      delete target.dataset.beingDragged
-    })
   }
 
-  buildMoveToken(target) {
-    return event => {
-      const { screenX, screenY } = event
-      const { originalX, originalY, dragStartX, dragStartY, tokenId } = target.dataset
-      const { zoomAmount } = this.imageTarget.dataset
+  moveToken(event) {
+    event.stopPropagation()
 
+    const { screenX, screenY, target } = event
+    const { x: currentX, y: currentY, originalX, originalY, dragStartX, dragStartY, tokenId } = target.dataset
+    const { zoomAmount } = this.imageTarget.dataset
+
+    const newX = parseInt(originalX) + ((screenX - parseInt(dragStartX)) / parseFloat(zoomAmount))
+    const newY = parseInt(originalY) + ((screenY - parseInt(dragStartY)) / parseFloat(zoomAmount))
+
+    if (newX != currentX || newY != currentY) {
       this.setTokenLocation(
         target,
         parseInt(originalX) + ((screenX - parseInt(dragStartX)) / parseFloat(zoomAmount)),
@@ -143,6 +142,18 @@ export default class extends Controller {
         }
       )
     }
+  }
+
+  endMoveToken({ target }) {
+    delete target.dataset.originalX
+    delete target.dataset.originalY
+    delete target.dataset.dragStartX
+    delete target.dataset.dragStartY
+    delete target.dataset.beingDragged
+  }
+
+  dragOver(event) {
+    event.preventDefault()
   }
 
   setMapZoom(zoom, amount, width, height) {

--- a/app/javascript/src/components/_map.scss
+++ b/app/javascript/src/components/_map.scss
@@ -21,3 +21,19 @@
   left: calc(((var(--viewport-x) / 2) - var(--x)) * 1px);
   top: calc(((var(--viewport-y) / 2) - var(--y)) * 1px);
 }
+
+.current-map__token-drawer {
+  @apply
+    h-screen
+    bg-gray-500
+  ;
+
+  --zoom-amount: 1.5;
+
+  .token {
+    @apply
+      static
+      m-2
+    ;
+  }
+}

--- a/app/javascript/src/components/_token.scss
+++ b/app/javascript/src/components/_token.scss
@@ -29,16 +29,27 @@
   width: calc(2rem * var(--zoom-amount));
 }
 
+.token__image-add {
+  @apply
+    text-2xl
+    text-center
+    bg-gray-300
+    text-gray-700
+  ;
+}
+
 .token__name {
   @apply
+    absolute
     hidden
     bg-white
     rounded-full
-    ml-2
     px-2
     text-xs
     z-10
     pointer-events-none;
+
+  margin-left: calc((2rem + 4px) * var(--zoom-amount));
 }
 
 .token:hover .token__name {

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -10,7 +10,7 @@
       controller: "map css-var",
       "map-id": campaign.current_map.id,
       target: "map.image",
-      action: dm?(campaign, "mousedown->map#moveMap"),
+      action: "dragover->map#dragOver #{dm?(campaign, "mousedown->map#moveMap")}",
       x: campaign.current_map.x,
       y: campaign.current_map.y,
       zoom: campaign.current_map.zoom,

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -1,39 +1,54 @@
 <% if campaign.current_map.present? %>
   <%= content_tag :h2, campaign.current_map.name %>
-  <% if dm?(campaign) %>
-    <%= link_to "New Token", new_map_token_path(campaign.current_map), remote: true %>
-  <% end %>
-
   <%= content_tag :div,
-    class: "current-map relative overflow-hidden",
     data: {
-      controller: "map css-var",
+      controller: "map",
       "map-id": campaign.current_map.id,
-      target: "map.image",
-      action: "dragover->map#dragOver #{dm?(campaign, "mousedown->map#moveMap")}",
-      x: campaign.current_map.x,
-      y: campaign.current_map.y,
-      zoom: campaign.current_map.zoom,
-      "zoom-amount": campaign.current_map.zoom_amount,
-      height: campaign.current_map.height,
-      width: campaign.current_map.width,
-      "zoom-max": campaign.current_map.zoom_max,
-      "css-vars": "x y viewport-x viewport-y width height zoom-amount"
-    },
-    style: "background-image: url('#{url_for campaign.current_map.image}');" do %>
-    <div class="current-map__token-container" data-target="map.tokenContainer">
-      <%= render campaign.current_map.tokens %>
+    } do %>
+    <div class="flex flex-row">
+      <% if dm?(campaign) %>
+        <div class="current-map__token-drawer token-drawer" data-target="map.tokenDrawer" data-action="dragover->map#dragOverDrawer drop->map#dropOnDrawer">
+          <% if dm?(campaign) %>
+            <%= link_to new_map_token_path(campaign.current_map), remote: true, class: "token new-token-link" do %>
+              <span class="token__image token__image-add">+</span>
+            <% end %>
+          <% end %>
+
+          <%= render campaign.current_map.tokens.where(stashed: true) %>
+        </div>
+      <% end %>
+      <%= content_tag :div,
+        class: "current-map relative overflow-hidden",
+        data: {
+          controller: "css-var",
+          "map-id": campaign.current_map.id,
+          target: "map.image",
+          action: "dragover->map#dragOverMap drop->map#dropOnMap #{dm?(campaign, "mousedown->map#moveMap")}",
+          x: campaign.current_map.x,
+          y: campaign.current_map.y,
+          zoom: campaign.current_map.zoom,
+          "zoom-amount": campaign.current_map.zoom_amount,
+          height: campaign.current_map.height,
+          width: campaign.current_map.width,
+          "zoom-max": campaign.current_map.zoom_max,
+          "css-vars": "x y viewport-x viewport-y width height zoom-amount"
+        },
+        style: "background-image: url('#{url_for campaign.current_map.image}');" do %>
+        <div class="current-map__token-container" data-target="map.tokenContainer">
+          <%= render campaign.current_map.tokens.where(stashed: false) %>
+        </div>
+        <% if dm?(campaign) %>
+          <div class="controls w-16 absolute top-0 right-0 m-2 flex justify-center">
+            <%= button_tag class: "current-map__zoom-out flex-1 text-center border rounded-l-md h-7 bg-gray-200 cursor-default", data: { target: "map.zoomOut", action: "click->map#zoomOut" } do %>
+              -
+            <% end %>
+            <%= button_tag class: "current-map__zoom-in flex-1 text-center border rounded-r-md h-7 bg-gray-200 cursor-default", data: { target: "map.zoomIn", action: "click->map#zoomIn" } do %>
+              +
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
     </div>
-    <% if dm?(campaign) %>
-      <div class="controls w-16 absolute top-0 right-0 m-2 flex justify-center">
-        <%= button_tag class: "flex-1 text-center border rounded-l-md h-7 bg-gray-200 cursor-default", data: { target: "map.zoomOut", action: "click->map#zoomOut" } do %>
-          -
-        <% end %>
-        <%= button_tag class: "flex-1 text-center border rounded-r-md h-7 bg-gray-200 cursor-default", data: { target: "map.zoomIn", action: "click->map#zoomIn" } do %>
-          +
-        <% end %>
-      </div>
-    <% end %>
   <% end %>
 <% else %>
   <h2>No Current Map</h2>

--- a/app/views/tokens/_token.html.erb
+++ b/app/views/tokens/_token.html.erb
@@ -1,9 +1,10 @@
 <%= content_tag :div,
   class: "token",
+  draggable: true,
   data: {
     controller: "css-var",
     target: "map.token",
-    action: "mousedown->map#startMoveToken",
+    action: "dragstart->map#startMoveToken drag->map#moveToken dragend->map#endMoveToken mousedown->map#stopPropagation",
     token_id: token.id,
     x: token.x,
     y: token.y,

--- a/db/migrate/20200426085659_add_stashed_to_tokens.rb
+++ b/db/migrate/20200426085659_add_stashed_to_tokens.rb
@@ -1,0 +1,5 @@
+class AddStashedToTokens < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tokens, :stashed, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_18_154404) do
+ActiveRecord::Schema.define(version: 2020_04_26_085659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2020_04_18_154404) do
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "tokenable_id"
     t.string "tokenable_type"
+    t.boolean "stashed", default: true
     t.index ["map_id"], name: "index_tokens_on_map_id"
     t.index ["tokenable_type", "tokenable_id"], name: "index_tokens_on_tokenable_type_and_tokenable_id"
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -39,6 +39,7 @@ FactoryBot.define do
     sequence(:name) { |n| "Uxil#{n}" }
     x { rand(100) }
     y { rand(100) }
+    stashed { true }
     image do
       Rack::Test::UploadedFile.new("spec/fixtures/files/#{image_name}")
     end

--- a/spec/support/map.rb
+++ b/spec/support/map.rb
@@ -4,12 +4,25 @@ def have_map_with_data(map, attribute, value)
   )
 end
 
-def have_token_with_data(token, attribute, value)
-  have_css(
-    ".token[data-token-id='#{token.id}'][data-#{attribute}='#{value}']"
-  )
+RSpec::Matchers.define :have_token do |token|
+  match do |container|
+    container.has_css?(".token[data-token-id='#{token.to_param}']")
+  end
 end
 
-def have_token(token)
-  have_css(".token[data-token-id='#{token.id}']")
+RSpec::Matchers.define :have_token_with_data do |token, key, value|
+  match do |container|
+    container.has_css?(
+      ".token[data-token-id='#{token.to_param}'][data-#{key}='#{value}']"
+    )
+  end
+
+  failure_message do |container|
+    token_element = container.find(".token[data-token-id='#{token.to_param}']")
+    actual_value = token_element.native.attribute("data-#{key}")
+    <<~MSG
+      expected token to have attribute '#{key}' with value '#{value}' but
+      instead had value '#{actual_value}'
+    MSG
+  end
 end

--- a/spec/support/mouse.rb
+++ b/spec/support/mouse.rb
@@ -21,22 +21,22 @@ def click_and_move_token(token, by:)
   dispatch_event(
     element,
     "this",
-    mouse_event(
-      "mousedown",
+    drag_event(
+      "dragstart",
       screen_x: element.native.location.x,
       screen_y: element.native.location.y
     )
   )
   dispatch_event(
-    page,
-    "document",
-    mouse_event(
-      "mousemove",
+    element,
+    "this",
+    drag_event(
+      "drag",
       screen_x: by[:x] + element.native.location.x,
       screen_y: by[:y] + element.native.location.y
     )
   )
-  dispatch_event(page, "document", "new MouseEvent('mouseup')")
+  dispatch_event(element, "this", "new DragEvent('dragend')")
 end
 
 def token_element(token)
@@ -45,6 +45,10 @@ end
 
 def dispatch_event(node, element, event)
   node.execute_script("#{element}.dispatchEvent(#{event})")
+end
+
+def drag_event(event, screen_x:, screen_y:)
+  "new DragEvent('#{event}', { screenX: #{screen_x}, screenY: #{screen_y} })"
 end
 
 def mouse_event(event, screen_x:, screen_y:)

--- a/spec/system/create_tokens_spec.rb
+++ b/spec/system/create_tokens_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "create tokens", type: :system do
 
     visit campaign_path(map.campaign, as: user)
     wait_for_connection
-    click_on "New Token"
+    find(".new-token-link").click
     within "[data-controller=modal]" do
       fill_in "Name", with: "Olokas"
       attach_file "Image", file_fixture("olokas.jpeg")
@@ -33,7 +33,7 @@ RSpec.describe "create tokens", type: :system do
       visit campaign_path(map.campaign)
       wait_for_connection
     end
-    click_on "New Token"
+    find(".new-token-link").click
     fill_in "Name", with: "Olokas"
     attach_file "Image", file_fixture("olokas.jpeg")
     click_on "Create Token"

--- a/spec/system/manage_maps_spec.rb
+++ b/spec/system/manage_maps_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "manage maps", type: :system do
     expect(page).to have_map_with_data(map, "height", "100")
     expect(page).to have_button("-", disabled: true)
 
-    click_on "+"
+    find(".current-map__zoom-in").click
 
     expect(page).to have_map_with_data(map, "width", "200")
     expect(page).to have_map_with_data(map, "height", "200")
@@ -127,7 +127,7 @@ RSpec.describe "manage maps", type: :system do
     expect(page).to have_map_with_data(map, "height", "100")
     expect(page).to have_button("-", disabled: true)
 
-    click_on "+"
+    find(".current-map__zoom-in").click
 
     using_session "other user" do
       expect(page).to have_map_with_data(map, "width", "200")

--- a/spec/system/move_tokens_spec.rb
+++ b/spec/system/move_tokens_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "move tokens", type: :system do
   it "shows tokens on the map" do
     map = create :map
-    token = create :token, map: map
+    token = create :token, map: map, stashed: false
     visit campaign_path(map.campaign, as: map.campaign.user)
     wait_for_connection
     find(".map-selector__option", text: map.name).click
@@ -13,7 +13,7 @@ RSpec.describe "move tokens", type: :system do
   it "drags tokens" do
     map = create :map, zoom: 2
     map.campaign.update(current_map: map)
-    token = create :token, map: map, x: 0, y: 0
+    token = create :token, map: map, x: 0, y: 0, stashed: false
 
     visit campaign_path(map.campaign)
     wait_for_connection
@@ -26,7 +26,7 @@ RSpec.describe "move tokens", type: :system do
   it "factors in map zoom when dragging" do
     map = create :map, zoom: 0
     map.campaign.update(current_map: map)
-    token = create :token, map: map, x: 0, y: 0
+    token = create :token, map: map, x: 0, y: 0, stashed: false
 
     visit campaign_path(map.campaign)
     wait_for_connection
@@ -39,7 +39,7 @@ RSpec.describe "move tokens", type: :system do
   it "moves the token for other users" do
     map = create :map, zoom: 2
     map.campaign.update(current_map: map)
-    token = create :token, map: map, x: 0, y: 0
+    token = create :token, map: map, x: 0, y: 0, stashed: false
 
     visit campaign_path(map.campaign)
     wait_for_connection

--- a/spec/system/token_drawer_spec.rb
+++ b/spec/system/token_drawer_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe "token drawer", type: :system do
+  it "moves tokens from the drawer to the map" do
+    map = create :map
+    token = create :token, map: map, stashed: true
+    visit campaign_path(map.campaign, as: map.campaign.user)
+    wait_for_connection
+    find(".map-selector__option", text: map.name).click
+    token_element = token_element(token)
+    token_element.drag_to(map_element(map), html5: true)
+    expect(map_element(map)).to have_token(token)
+  end
+
+  it "adds the token to the map for other users" do
+    map = create :map
+    token = create :token, map: map, stashed: true
+
+    visit campaign_path(map.campaign, as: map.campaign.user)
+    find(".map-selector__option", text: map.name).click
+    wait_for_connection
+    using_session "other user" do
+      visit campaign_path(map.campaign)
+      wait_for_connection
+    end
+
+    token_element = token_element(token)
+    token_element.drag_to(map_element(map), html5: true)
+
+    using_session "other user" do
+      expect(page).to have_token(token)
+    end
+  end
+
+  it "moves tokens from the map to the drawer" do
+    map = create :map
+    token = create :token, map: map, stashed: false
+    visit campaign_path(map.campaign, as: map.campaign.user)
+    wait_for_connection
+    find(".map-selector__option", text: map.name).click
+    token_element = token_element(token)
+    token_element.drag_to(token_drawer_element, html5: true)
+    expect(token_drawer_element).to have_token(token)
+    expect(map_element(map)).not_to have_token(token)
+  end
+
+  it "hides the token for other users" do
+    map = create :map
+    token = create :token, map: map, stashed: false
+
+    visit campaign_path(map.campaign, as: map.campaign.user)
+    wait_for_connection
+    find(".map-selector__option", text: map.name).click
+    using_session "other user" do
+      visit campaign_path(map.campaign)
+      wait_for_connection
+    end
+
+    token_element = token_element(token)
+    token_element.drag_to(token_drawer_element, html5: true)
+
+    using_session "other user" do
+      expect(page).not_to have_token(token)
+    end
+  end
+
+  def token_drawer_element
+    find(".current-map__token-drawer")
+  end
+end


### PR DESCRIPTION
Introduces a token drawer to the left of the map. The DM can stash tokens in the drawer to hide them from players by dragging a token from the map to the drawer. If the DM drags a token from the drawer to the map then it appears for all of the players.

A lot of token movement has been replaced. This is to allow a token's position on the map to be calculated based on its absolute position, rather than the relative distance from its initial location. Doing this allows us to drag tokens onto the map and position them appropriately, which is required for retrieving tokens from the drawer.