### PR TITLE
Token Creation UI

### DIFF
--- a/app/channels/map_channel.rb
+++ b/app/channels/map_channel.rb
@@ -56,4 +56,27 @@ class MapChannel < ApplicationCable::Channel
       }
     )
   end
+
+  class << self
+    def add_token(token)
+      broadcast_to(
+        token.map,
+        {
+          operation: "addToken",
+          token_html: render_token(token),
+          x: token.x,
+          y: token.y
+        }
+      )
+    end
+
+    private
+
+    def render_token(token)
+      ApplicationController.renderer.render(
+        partial: "tokens/token",
+        locals: { token: token }
+      )
+    end
+  end
 end

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -1,0 +1,26 @@
+class TokensController < ApplicationController
+  before_action :require_login
+
+  def new
+    map = current_user.maps.find(params[:map_id])
+    render locals: { token: map.tokens.build }
+  end
+
+  def create
+    map = current_user.maps.find(params[:map_id])
+    token = map.tokens.new(token_params)
+    if token.save
+      redirect_to map.campaign
+    else
+      redirect_to map.campaign, flash: {
+        error: token.errors.full_messages.to_sentence
+      }
+    end
+  end
+
+  private
+
+  def token_params
+    params.require(:token).permit(:name, :image)
+  end
+end

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "stimulus"
 import consumer from "../channels/consumer"
 
 export default class extends Controller {
-  static targets = ["image", "zoomIn", "zoomOut", "token"]
+  static targets = ["image", "zoomIn", "zoomOut", "token", "tokenContainer"]
 
   connect() {
     this.mapId = this.element.dataset.mapId
@@ -181,6 +181,10 @@ export default class extends Controller {
           return
         }
         this.setTokenLocation(token, data.x, data.y)
+        break
+      }
+      case "addToken": {
+        this.tokenContainerTarget.insertAdjacentHTML("beforeend", data.token_html);
         break
       }
     }

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  close(event) {
+    event.preventDefault()
+    this.element.parentNode.removeChild(this.element)
+  }
+}

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -4,6 +4,7 @@
 
 @import "components/map";
 @import "components/map_selector";
+@import "components/modal";
 @import "components/token";
 @import "components/character";
 @import "components/flashes";

--- a/app/javascript/src/components/_modal.scss
+++ b/app/javascript/src/components/_modal.scss
@@ -1,0 +1,5 @@
+$modal-background: rgba(127, 127, 127, 0.5);
+
+.modal {
+  background-color: $modal-background;
+}

--- a/app/jobs/token_broadcast_job.rb
+++ b/app/jobs/token_broadcast_job.rb
@@ -1,0 +1,7 @@
+class TokenBroadcastJob < ApplicationJob
+  queue_as :default
+
+  def perform(token)
+    MapChannel.add_token(token)
+  end
+end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -6,6 +6,8 @@ class Token < ApplicationRecord
   validates :name, presence: true
   validates :image, presence: true
 
+  after_create_commit :broadcast_token_creation
+
   def name
     read_attribute(:name).presence || tokenable.try(:name)
   end
@@ -13,5 +15,11 @@ class Token < ApplicationRecord
   token_image = instance_method(:image)
   define_method(:image) do
     token_image.bind(self).().presence || tokenable.try(:image)
+  end
+
+  private
+
+  def broadcast_token_creation
+    TokenBroadcastJob.perform_later(self)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   include Clearance::User
 
   has_many :campaigns, dependent: :destroy
+  has_many :maps, through: :campaigns
 
   validates :name, presence: true
 end

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -1,5 +1,8 @@
 <% if campaign.current_map.present? %>
   <%= content_tag :h2, campaign.current_map.name %>
+  <% if dm?(campaign) %>
+    <%= link_to "New Token", new_map_token_path(campaign.current_map), remote: true %>
+  <% end %>
 
   <%= content_tag :div,
     class: "current-map relative overflow-hidden",

--- a/app/views/layouts/campaign.html.erb
+++ b/app/views/layouts/campaign.html.erb
@@ -12,6 +12,8 @@
   <body>
     <%= render partial: "header", locals: { full_width: true } %>
     <div class="mx-4 py-4">
+      <%= render "flashes" %>
+
       <%= yield %>
     </div>
   </body>

--- a/app/views/tokens/_new.html.erb
+++ b/app/views/tokens/_new.html.erb
@@ -1,0 +1,18 @@
+<div data-controller="modal" class="modal h-screen w-full fixed flex items-center justify-center top-0 left-0">
+  <div class="bg-white rounded shadow-xl p-8 m-4 max-w-sm border-solid border border-gray max-h-full overflow-y-scroll">
+    <h1 class="text-4xl">New Token</h1>
+    <hr class="my-2" />
+    <%= form_with model: [token.map, token], local: true, class: "my-2" do |form| %>
+      <%= form.label :name %>
+      <%= form.text_field :name, class: "input" %>
+
+      <%= form.label :image %>
+      <%= form.file_field :image, class: "input" %>
+
+      <div class="flex items-center justify-between">
+        <%= form.submit class: "btn" %>
+        <%= link_to "Cancel", "#", data: { action: "click->modal#close" }, class: "inline-block align-baseline text-sm text-gray-500 hover:text-gray-800" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/tokens/new.js.erb
+++ b/app/views/tokens/new.js.erb
@@ -1,0 +1,1 @@
+document.body.insertAdjacentHTML("beforeend", "<%= j render "new", token: token %>");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,9 @@ Rails.application.routes.draw do
   get "/sign_up" => "clearance/users#new", as: "sign_up"
   resources :campaigns, only: %i[index new create show] do
     resources :characters
-    resources :maps, only: %i[new create], shallow: true
+    resources :maps, only: %i[new create], shallow: true do
+      resources :tokens, only: %i[new create]
+    end
   end
 
   root controller: :campaigns, action: :index

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,7 +73,6 @@ ActiveRecord::Schema.define(version: 2020_04_18_154404) do
     t.integer "y"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "in_drawer", default: true
     t.uuid "tokenable_id"
     t.string "tokenable_type"
     t.index ["map_id"], name: "index_tokens_on_map_id"

--- a/spec/system/create_tokens_spec.rb
+++ b/spec/system/create_tokens_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "create tokens", type: :system do
+  it "creates a with name and image, showing it on the map" do
+    user = create(:user)
+    campaign = create(:campaign, user: user)
+    map = create(:map, campaign: campaign)
+    map.campaign.update(current_map: map)
+    expect(map.tokens).to be_empty
+
+    visit campaign_path(map.campaign, as: user)
+    wait_for_connection
+    click_on "New Token"
+    within "[data-controller=modal]" do
+      fill_in "Name", with: "Olokas"
+      attach_file "Image", file_fixture("olokas.jpeg")
+      click_on "Create Token"
+    end
+
+    token = map.reload.tokens.first
+    expect(page).to have_token(token)
+  end
+
+  it "shows the new token to other users" do
+    user = create(:user)
+    campaign = create(:campaign, user: user)
+    map = create(:map, campaign: campaign)
+    map.campaign.update(current_map: map)
+
+    visit campaign_path(map.campaign, as: user)
+    wait_for_connection
+    using_session "other user" do
+      visit campaign_path(map.campaign)
+      wait_for_connection
+    end
+    click_on "New Token"
+    fill_in "Name", with: "Olokas"
+    attach_file "Image", file_fixture("olokas.jpeg")
+    click_on "Create Token"
+
+    token = map.reload.tokens.first
+    using_session "other user" do
+      expect(page).to have_token(token)
+    end
+  end
+end


### PR DESCRIPTION
This adds a UI for creating new tokens on a map. When the DM creates a new token, it is broadcast to all players.

I haven't worried about the design of the "New Token" link as I imagine it will get moved inside the drawer, which is being introduced in #28.

![Create token](https://user-images.githubusercontent.com/5015/79933507-36b5f080-841e-11ea-94a6-b097cdaee9ea.png)

When the DM uploads a token, there is a full page refresh because that's how file uploads have to work unless we do a lot more fancy stuff.