### PR TITLE
Don't let token names wrap

### DIFF
--- a/app/javascript/src/components/_token.scss
+++ b/app/javascript/src/components/_token.scss
@@ -51,7 +51,9 @@
     px-2
     text-xs
     z-10
-    pointer-events-none;
+    pointer-events-none
+    whitespace-no-wrap
+  ;
 
   margin-left: calc((2rem + 4px) * var(--zoom-amount));
 }


### PR DESCRIPTION
Fixes #53, by adding white-space: nowrap; this prevents wrapping then
within an element.

<img width="467" alt="Screen Shot 2020-05-09 at 8 32 31 AM" src="https://user-images.githubusercontent.com/5015/81473897-dec60a80-91cf-11ea-89b3-e33f227724bb.png">