### PR TITLE
Fix token dragging in Firefox

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -130,10 +130,20 @@ export default class extends Controller {
     event.stopPropagation()
   }
 
+  dragOver(event) {
+    this.recordPointerLocation(event.clientX, event.clientY)
+  }
+
+  recordPointerLocation(clientX, clientY) {
+    this.element.dataset.clientX = clientX
+    this.element.dataset.clientY = clientY
+  }
+
   startMoveToken(event) {
     event.stopPropagation()
 
     const { target, clientX, clientY } = event
+    this.recordPointerLocation(event.clientX, event.clientY)
     const { left, top } = target.getBoundingClientRect()
 
     const tokenImage = target.getElementsByClassName("token__image")[0]
@@ -152,9 +162,12 @@ export default class extends Controller {
     const { target } = event
     const { x: currentX, y: currentY, offsetX, offsetY, tokenId } = target.dataset
     const { zoomAmount } = this.imageTarget.dataset
-
-
-    const { x, y } = this.mapPositionOf(event)
+    const { x, y } = this.mapPositionOf(
+      new MouseEvent("drag", {
+        clientX: this.element.dataset.clientX,
+        clientY: this.element.dataset.clientY
+      })
+    )
 
     const newX = Math.floor(x + (parseFloat(offsetX) / parseFloat(zoomAmount)))
     const newY = Math.floor(y + (parseFloat(offsetY) / parseFloat(zoomAmount)))

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -4,6 +4,7 @@
     data: {
       controller: "map",
       "map-id": campaign.current_map.id,
+      action: "dragover->map#dragOver"
     } do %>
     <div class="flex flex-row">
       <% if dm?(campaign) %>

--- a/spec/support/mouse.rb
+++ b/spec/support/mouse.rb
@@ -58,6 +58,24 @@ def click_and_move_token(token, by:)
     )
   )
   dispatch_event(
+    element.ancestor("[data-controller='map']"),
+    "this",
+    drag_event(
+      "dragover",
+      client_x: by[:x] + element.native.location.x,
+      client_y: by[:y] + element.native.location.y
+    )
+  )
+  dispatch_event(
+    element,
+    "this",
+    drag_event(
+      "drag",
+      client_x: by[:x] + element.native.location.x,
+      client_y: by[:y] + element.native.location.y
+    )
+  )
+  dispatch_event(
     element,
     "this",
     drag_event(


### PR DESCRIPTION
Fixes #54

`clientX` and `clientY` are always set to 0 in Firefox on the drag event.

This is a bug in Firefox that has been open for 11 years
(https://bugzilla.mozilla.org/show_bug.cgi?id=505521).

We can get `clientX` and `clientY` in drag start, and by setting a
`dragover` handler on the entire map. To workaround this we set `clientX`
and `clientY` in the data of the map and use that instead of the
`clientX` and `clientY` from the `drag` event.