### PR TITLE
Fix displaying dm controls when switching maps

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -2,17 +2,6 @@ module ApplicationCable
   class Channel < ActionCable::Channel::Base
     protected
 
-    def render_partial(partial, options = {})
-      ActionController::Renderer::RACK_KEY_TRANSLATION[:clearance] ||=
-        :clearance
-      clearance_session = Clearance::Session.new({}).tap do |session|
-        session.sign_in(current_user)
-      end
-      ApplicationController.renderer.new(clearance: clearance_session).render(
-        options.merge(partial: partial)
-      )
-    end
-
     def dm?(campaign)
       campaign.user == current_user
     end

--- a/app/channels/campaign_channel.rb
+++ b/app/channels/campaign_channel.rb
@@ -12,13 +12,7 @@ class CampaignChannel < ApplicationCable::Channel
     campaign.update(current_map: map)
     broadcast_to(
       campaign,
-      current_map_html: render_current_map(campaign)
+      operation: "change_current_map"
     )
-  end
-
-  private
-
-  def render_current_map(campaign)
-    render_partial("campaigns/current_map", locals: { campaign: campaign })
   end
 end

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -19,7 +19,17 @@ class CampaignsController < ApplicationController
   end
 
   def show
-    render locals: { campaign: Campaign.find(params[:id]) }, layout: "campaign"
+    campaign = Campaign.find(params[:id])
+    if request.xhr?
+      render json: {
+        html: render_to_string(
+          partial: "campaigns/current_map",
+          locals: { campaign: campaign }
+        )
+      }
+    else
+      render locals: { campaign: campaign }, layout: "campaign"
+    end
   end
 
   private

--- a/app/javascript/controllers/campaign_controller.js
+++ b/app/javascript/controllers/campaign_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "stimulus"
 import consumer from "../channels/consumer"
+import Rails from "@rails/ujs"
 
 export default class extends Controller {
   static targets = ["mapOption", "currentMap", "statusIndicator"]
@@ -27,6 +28,17 @@ export default class extends Controller {
   }
 
   cableReceived(data) {
-    this.currentMapTarget.innerHTML = data.current_map_html
+    switch (data.operation) {
+      case "change_current_map": {
+        Rails.ajax({
+          url: window.location.href,
+          type: "get",
+          success: data => {
+            this.currentMapTarget.innerHTML = data.html
+          }
+        })
+        break
+      }
+    }
   }
 }

--- a/spec/system/manage_maps_spec.rb
+++ b/spec/system/manage_maps_spec.rb
@@ -149,11 +149,13 @@ RSpec.describe "manage maps", type: :system do
     find(".map-selector__option", text: "Dwarven Excavation").click
     using_session "other user" do
       expect(page).to have_css "h2", text: "Dwarven Excavation"
+      expect(page).not_to have_css("[data-target='map.tokenDrawer']")
     end
 
     find(".map-selector__option", text: "Gnomengarde").click
     using_session "other user" do
       expect(page).to have_css "h2", text: "Gnomengarde"
+      expect(page).not_to have_css("[data-target='map.tokenDrawer']")
     end
   end
 end


### PR DESCRIPTION
Fixes #55. Previously when switching maps it was broadcasting the
rendered map partial to all users, but that was being rendered by the dm
users.

This fixes the problem by broadcasting a chang_current_map operation to
everyone subscribed to the channel and having each person get their own
version of the map.

I explored a few different ways of handling this, and this was the
simplest/best fix I could figure.