### PR TITLE
Fix displaying dm controls when switching maps

### DIFF
--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -7,12 +7,10 @@
       action: "dragover->map#dragOver"
     } do %>
     <div class="flex flex-row">
-      <% if dm?(campaign) %>
+      <% if admin %>
         <div class="current-map__token-drawer token-drawer" data-target="map.tokenDrawer" data-action="dragover->map#dragOverDrawer drop->map#dropOnDrawer">
-          <% if dm?(campaign) %>
-            <%= link_to new_map_token_path(campaign.current_map), remote: true, title: "New Token", class: "token new-token-link" do %>
-              <span class="token__image token__image-add">+</span>
-            <% end %>
+          <%= link_to new_map_token_path(campaign.current_map), remote: true, title: "New Token", class: "token new-token-link" do %>
+            <span class="token__image token__image-add">+</span>
           <% end %>
 
           <%= render campaign.current_map.tokens.where(stashed: true) %>
@@ -24,7 +22,7 @@
           controller: "css-var",
           "map-id": campaign.current_map.id,
           target: "map.image",
-          action: "dragover->map#dragOverMap drop->map#dropOnMap mousedown->map#pointTo #{dm?(campaign, "mousedown->map#moveMap")}",
+          action: "dragover->map#dragOverMap drop->map#dropOnMap mousedown->map#pointTo #{"mousedown->map#moveMap" if admin}",
           x: campaign.current_map.x,
           y: campaign.current_map.y,
           zoom: campaign.current_map.zoom,
@@ -38,7 +36,7 @@
         <div class="current-map__token-container" data-target="map.tokenContainer">
           <%= render campaign.current_map.tokens.where(stashed: false) %>
         </div>
-        <% if dm?(campaign) %>
+        <% if admin %>
           <div class="controls w-16 absolute top-0 right-0 m-2 flex justify-center">
             <%= button_tag class: "current-map__zoom-out flex-1 text-center border rounded-l-md h-7 bg-gray-200 cursor-default", data: { target: "map.zoomOut", action: "click->map#zoomOut" } do %>
               -

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 
   <div data-target="campaign.currentMap">
-    <%= render partial: "current_map", locals: { campaign: campaign } %>
+    <%= render partial: "current_map", locals: { campaign: campaign, admin: dm?(campaign) } %>
   </div>
 
   <div data-target="campaign.statusIndicator" class="absolute top-0 left-0 w-full h-full bg-white flex items-center justify-center opacity-50">

--- a/spec/system/manage_maps_spec.rb
+++ b/spec/system/manage_maps_spec.rb
@@ -149,11 +149,13 @@ RSpec.describe "manage maps", type: :system do
     find(".map-selector__option", text: "Dwarven Excavation").click
     using_session "other user" do
       expect(page).to have_css "h2", text: "Dwarven Excavation"
+      expect(page).not_to have_css("[data-target='map.tokenDrawer']")
     end
 
     find(".map-selector__option", text: "Gnomengarde").click
     using_session "other user" do
       expect(page).to have_css "h2", text: "Gnomengarde"
+      expect(page).not_to have_css("[data-target='map.tokenDrawer']")
     end
   end
 end


### PR DESCRIPTION
Fixes #55. This addresses the issue in #55 by creating two channels, one
for the dm and the other for everyone else, and broadcasting map changes
with the appropriate html to each of them.

The change in the `_current_map` partial ended up being straightforward,
instead of checking within the partial if the person is the dm, move the
check up out of it and pass it in as a local variable.