### PR TITLE
Token sizes

### DIFF
--- a/app/controllers/creatures_controller.rb
+++ b/app/controllers/creatures_controller.rb
@@ -51,6 +51,6 @@ class CreaturesController < ApplicationController
   end
 
   def creature_params
-    params.require(:creature).permit(:name, :image)
+    params.require(:creature).permit(:name, :image, :size)
   end
 end

--- a/app/helpers/token_helper.rb
+++ b/app/helpers/token_helper.rb
@@ -1,0 +1,5 @@
+module TokenHelper
+  def options_for_token_size
+    Token.size_names.map { |name| [name.capitalize, name] }
+  end
+end

--- a/app/javascript/src/components/_map.scss
+++ b/app/javascript/src/components/_map.scss
@@ -28,12 +28,22 @@
     bg-gray-500
   ;
 
-  --zoom-amount: 1.5;
+  --drawer-scale: 1.25;
 
   .token {
     @apply
       static
       m-2
     ;
+
+    .token__image {
+      border-width: calc(var(--base-border) * var(--drawer-scale));
+      height: calc(var(--base-size) * var(--drawer-scale));
+      width: calc(var(--base-size) * var(--drawer-scale));
+    }
+
+    .token__name {
+      margin-left: calc((var(--base-size) + 4px) * var(--drawer-scale));
+    }
   }
 }

--- a/app/javascript/src/components/_token.scss
+++ b/app/javascript/src/components/_token.scss
@@ -8,9 +8,12 @@
     items-center
     absolute;
 
+  --base-border: 2px;
+  --base-size: 36px;
+
   left: calc(var(--x) * var(--zoom-amount) * 1px);
-  margin-left: calc(-1rem * var(--zoom-amount));
-  margin-top: calc(-1rem * var(--zoom-amount));
+  margin-left: calc((-1 * (var(--base-size) / 2)) * var(--size-scale) * var(--zoom-amount));
+  margin-top: calc((-1 * (var(--base-size) / 2)) * var(--size-scale) * var(--zoom-amount));
   top: calc(var(--y) * var(--zoom-amount) * 1px);
 }
 
@@ -18,6 +21,7 @@
   @apply
     bg-cover
     bg-center
+    bg-gray-300
     rounded-full
     border-white
     pointer-events-none
@@ -27,9 +31,9 @@
     items-end
     justify-end;
 
-  border-width: calc(2px * var(--zoom-amount));
-  height: calc(2rem * var(--zoom-amount));
-  width: calc(2rem * var(--zoom-amount));
+  border-width: calc(var(--base-border) * var(--size-scale) * var(--zoom-amount));
+  height: calc((var(--base-size) * var(--size-scale) * var(--zoom-amount)));
+  width: calc((var(--base-size) * var(--size-scale) * var(--zoom-amount)));
 }
 
 .token__image-add {
@@ -55,7 +59,7 @@
     whitespace-no-wrap
   ;
 
-  margin-left: calc((2rem + 4px) * var(--zoom-amount));
+  margin-left: calc((var(--base-size) * var(--size-scale) + (2 * var(--base-border))) * var(--zoom-amount));
 }
 
 .token__identifier {

--- a/app/models/creature.rb
+++ b/app/models/creature.rb
@@ -6,6 +6,7 @@ class Creature < ApplicationRecord
   validates :campaign, presence: true
   validates :image, presence: true
   validates :name, presence: true
+  validates_inclusion_of :size, in: Token.size_names
 
   def copy_on_place?
     true

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -1,15 +1,32 @@
 class Token < ApplicationRecord
+  SIZES = {
+    "tiny" => 0.5,
+    "small" => 1,
+    "medium" => 1,
+    "large" => 2,
+    "huge" => 3,
+    "gargantuan" => 4
+  }.freeze
   belongs_to :map
   belongs_to :tokenable, polymorphic: true, optional: true
   has_one_attached :image
 
   validates :name, presence: true
   validates :image, presence: true
+  validates_inclusion_of :size, in: SIZES.keys, allow_blank: true
 
   after_create_commit :broadcast_token_creation
 
+  def self.size_names
+    SIZES.keys
+  end
+
   def name
     read_attribute(:name).presence || tokenable.try(:name)
+  end
+
+  def size
+    read_attribute(:size).presence || tokenable.try(:size)
   end
 
   token_image = instance_method(:image)
@@ -19,6 +36,10 @@ class Token < ApplicationRecord
 
   def copy_on_place?
     identifier.blank? && tokenable&.copy_on_place?
+  end
+
+  def size_scale
+    SIZES[size]
   end
 
   private

--- a/app/views/creatures/_form.html.erb
+++ b/app/views/creatures/_form.html.erb
@@ -4,6 +4,9 @@
   <%= form.label :name %>
   <%= form.text_field :name, class: "input" %>
 
+  <%= form.label :size %>
+  <%= form.select :size, options_for_token_size, {}, class: "input" %>
+
   <%= form.label :image %>
   <%= form.file_field :image, class: "input" %>
 

--- a/app/views/tokens/_token.html.erb
+++ b/app/views/tokens/_token.html.erb
@@ -8,8 +8,9 @@
     token_id: token.id,
     x: token.x,
     y: token.y,
+    "size-scale": token.size_scale,
     copy_on_place: token.copy_on_place?,
-    "css-vars": "x y"
+    "css-vars": "x y size-scale"
   } do %>
   <%= content_tag :div, "", class: "token__image", style: background_image(token.image) do %>
     <% if token.identifier.present? %>

--- a/db/migrate/20200517115412_add_size_to_tokens.rb
+++ b/db/migrate/20200517115412_add_size_to_tokens.rb
@@ -1,0 +1,7 @@
+class AddSizeToTokens < ActiveRecord::Migration[6.0]
+  def change
+    add_column :creatures, :size, :string, null: false, default: "medium"
+    add_column :tokens, :size, :string, null: true
+    add_column :characters, :size, :string, null: false, default: "medium"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_30_015547) do
+ActiveRecord::Schema.define(version: 2020_05_17_115412) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -51,6 +52,7 @@ ActiveRecord::Schema.define(version: 2020_04_30_015547) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "size", default: "medium", null: false
     t.index ["campaign_id"], name: "index_characters_on_campaign_id"
   end
 
@@ -59,6 +61,7 @@ ActiveRecord::Schema.define(version: 2020_04_30_015547) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "size", default: "medium", null: false
     t.index ["campaign_id"], name: "index_creatures_on_campaign_id"
   end
 
@@ -84,6 +87,7 @@ ActiveRecord::Schema.define(version: 2020_04_30_015547) do
     t.string "tokenable_type"
     t.boolean "stashed", default: true
     t.string "identifier"
+    t.string "size"
     t.index ["map_id"], name: "index_tokens_on_map_id"
     t.index ["tokenable_type", "tokenable_id"], name: "index_tokens_on_tokenable_type_and_tokenable_id"
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -52,6 +52,7 @@ FactoryBot.define do
     x { rand(100) }
     y { rand(100) }
     stashed { true }
+    size { "medium" }
     image do
       Rack::Test::UploadedFile.new("spec/fixtures/files/#{image_name}")
     end

--- a/spec/models/creature_spec.rb
+++ b/spec/models/creature_spec.rb
@@ -12,5 +12,11 @@ RSpec.describe Creature, type: :model do
     it { is_expected.to validate_presence_of :campaign }
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :image }
+
+    it do
+      expect(described_class.new).to(
+        validate_inclusion_of(:size).in_array(Token::SIZES.keys)
+      )
+    end
   end
 end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe Token, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :image }
+
+    it do
+      expect(described_class.new).to(
+        validate_inclusion_of(:size).in_array(Token::SIZES.keys).allow_blank
+      )
+    end
   end
 
   describe "#name" do
@@ -26,6 +32,22 @@ RSpec.describe Token, type: :model do
       token = described_class.new(name: "", tokenable: character)
 
       expect(token.name).to eq "Character Name"
+    end
+  end
+
+  describe "#size" do
+    it "returns the token's size if overridden" do
+      character = build(:creature, size: :large)
+      token = described_class.new(size: :tiny, tokenable: character)
+
+      expect(token.size).to eq "tiny"
+    end
+
+    it "returns the tokenable's name if not overridden" do
+      character = build(:creature, size: :large)
+      token = described_class.new(size: nil, tokenable: character)
+
+      expect(token.size).to eq "large"
     end
   end
 
@@ -76,6 +98,14 @@ RSpec.describe Token, type: :model do
       token = described_class.new(identifier: "1", tokenable: Creature.new)
 
       expect(token).not_to be_copy_on_place
+    end
+  end
+
+  describe "#size_scale" do
+    it "return the scale number corresponding the token's size" do
+      token = described_class.new(size: "large")
+
+      expect(token.size_scale).to eq Token::SIZES["large"]
     end
   end
 end

--- a/spec/system/manage_creatures_spec.rb
+++ b/spec/system/manage_creatures_spec.rb
@@ -20,6 +20,35 @@ RSpec.describe "manage creatures", type: :system do
     expect(token.name).to eq "Orc"
   end
 
+  it "can create a large creature token" do
+    base_token_size = 36
+    base_drawer_size = (base_token_size * 1.25).round
+    large_map_size = (base_token_size * Token::SIZES["large"]).round
+    user = create(:user)
+    campaign = create(:campaign, user: user)
+    map = create(:map, campaign: campaign, zoom: 2)
+    campaign.update(current_map: map)
+
+    visit campaign_path(campaign, as: user)
+    click_on "New Token"
+    fill_in "Name", with: "Ogre"
+    select "Large"
+    attach_file "Image", file_fixture("uxil.jpeg")
+    click_on "Create Creature"
+
+    drawer_token = find(
+      ".current-map__token-drawer .token[data-target='map.token']"
+    )
+    expect(drawer_token.native.size.width).to eq base_drawer_size
+    expect(drawer_token.native.size.height).to eq base_drawer_size
+
+    drawer_token.drag_to(map_element(map), html5: true)
+
+    map_token = find(".current-map .token[data-target='map.token']")
+    expect(map_token.native.size.width).to eq large_map_size
+    expect(map_token.native.size.height).to eq large_map_size
+  end
+
   it "copies creature tokens from the drawer to the map" do
     map = create :map
     creature = create :creature, campaign: map.campaign


### PR DESCRIPTION
Closes #57. This adds support for multiple token sizes.

The duplication in the fields will go away with our upcoming token
changes, but I figured I'd plow through for now.

The base token height and width were changed from `rem` to `px` in order to ensure that the tokens were the sizes we expect. What was happening previously was that in order to double the size of a token, you needed to multiply it by ~2.75. Changes to pixels allows us to double the token size by multiplying it by two.