### PR TITLE
Add grid size attribute to normalize map scale

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -21,6 +21,6 @@ class MapsController < ApplicationController
   private
 
   def map_params
-    params.require(:map).permit(:name, :image)
+    params.require(:map).permit(:name, :image, :grid_size)
   end
 end

--- a/app/javascript/src/components/_token.scss
+++ b/app/javascript/src/components/_token.scss
@@ -9,7 +9,7 @@
     absolute;
 
   --base-border: 2px;
-  --base-size: 36px;
+  --base-size: 40px;
 
   left: calc(var(--x) * var(--zoom-amount) * 1px);
   margin-left: calc((-1 * (var(--base-size) / 2)) * var(--size-scale) * var(--zoom-amount));

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -1,5 +1,6 @@
 class Map < ApplicationRecord
   ZOOM_LEVELS = [0.25, 0.5, 1, 1.5, 2].freeze
+  NORMALIZED_GRID_SIZE = 50
 
   belongs_to :campaign
   has_many :tokens, dependent: :destroy
@@ -8,6 +9,7 @@ class Map < ApplicationRecord
 
   validates :name, presence: true
   validates :image, presence: true
+  validates :grid_size, presence: true, numericality: true
   validates_inclusion_of :zoom, in: ->(map) { (0..map.zoom_max) }
 
   before_update :scale_coordinates
@@ -24,12 +26,20 @@ class Map < ApplicationRecord
     image.metadata[:width]
   end
 
+  def scaled_height
+    original_height * NORMALIZED_GRID_SIZE / grid_size
+  end
+
+  def scaled_width
+    original_width * NORMALIZED_GRID_SIZE / grid_size
+  end
+
   def height
-    (original_height * zoom_amount).round
+    (scaled_height * zoom_amount).round
   end
 
   def width
-    (original_width * zoom_amount).round
+    (scaled_width * zoom_amount).round
   end
 
   def center_image

--- a/app/views/maps/new.html.erb
+++ b/app/views/maps/new.html.erb
@@ -18,6 +18,9 @@
     <%= form.label :image %>
     <%= form.file_field :image, class: "input" %>
 
+    <%= form.label :grid_size %>
+    <%= form.text_field :grid_size, class: "input" %>
+
     <%= form.submit class: "btn" %>
   <% end %>
 </div>

--- a/db/migrate/20200523105928_add_grid_size_to_maps.rb
+++ b/db/migrate/20200523105928_add_grid_size_to_maps.rb
@@ -1,0 +1,5 @@
+class AddGridSizeToMaps < ActiveRecord::Migration[6.0]
+  def change
+    add_column :maps, :grid_size, :integer, default: 43, null: false
+  end
+end

--- a/db/migrate/20200523115746_remove_grid_size_default.rb
+++ b/db/migrate/20200523115746_remove_grid_size_default.rb
@@ -1,0 +1,5 @@
+class RemoveGridSizeDefault < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :maps, :grid_size, from: 43, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_17_115412) do
+ActiveRecord::Schema.define(version: 2020_05_23_115746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 2020_05_17_115412) do
     t.integer "x", default: 0, null: false
     t.integer "y", default: 0, null: false
     t.integer "zoom", default: 0, null: false
+    t.integer "grid_size", null: false
     t.index ["campaign_id"], name: "index_maps_on_campaign_id"
   end
 

--- a/lib/tasks/dev/prime.rake
+++ b/lib/tasks/dev/prime.rake
@@ -48,7 +48,8 @@ namespace :dev do
       }
     ].each do |details|
       map = campaign.maps.find_or_create_by(
-        name: details[:name]
+        name: details[:name],
+        grid_size: 43
       ) do |map_record|
         map_record.image.attach(
           io: File.open(

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -35,6 +35,7 @@ FactoryBot.define do
 
     campaign
     name { "Dwarven Excavation" }
+    grid_size { 50 }
     image do
       Rack::Test::UploadedFile.new("spec/fixtures/files/#{image_name}")
     end

--- a/spec/models/map_spec.rb
+++ b/spec/models/map_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Map, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :image }
+    it { is_expected.to validate_presence_of :grid_size }
+    it { is_expected.to validate_numericality_of :grid_size }
     it { is_expected.to validate_inclusion_of(:zoom).in_range(0..4) }
   end
 
@@ -40,13 +42,31 @@ RSpec.describe Map, type: :model do
     end
   end
 
+  describe "#scaled_height" do
+    it "returns the height adjusted to a 50px grid size" do
+      map = create(:map, grid_size: 25)
+      map.image.analyze
+
+      expect(map.scaled_height).to eq(map.original_height * 2)
+    end
+  end
+
+  describe "#scaled_width" do
+    it "returns the width adjusted to a 50px grid size" do
+      map = create(:map, grid_size: 25)
+      map.image.analyze
+
+      expect(map.scaled_width).to eq(map.original_width * 2)
+    end
+  end
+
   describe "#height" do
     it "returns the integer zoomed height" do
       map = create(:map, zoom: 0)
       map.image.analyze
 
       expect(map.height).to eq(
-        (map.image.metadata[:height] * map.zoom_amount).round
+        (map.scaled_height * map.zoom_amount).round
       )
     end
   end
@@ -57,7 +77,7 @@ RSpec.describe Map, type: :model do
       map.image.analyze
 
       expect(map.width).to eq(
-        (map.image.metadata[:width] * map.zoom_amount).round
+        (map.scaled_width * map.zoom_amount).round
       )
     end
   end
@@ -69,7 +89,7 @@ RSpec.describe Map, type: :model do
       map.center_image
 
       expect(map.x).to eq(
-        ((map.original_width * map.zoom_amount) / 2).round
+        ((map.scaled_width * map.zoom_amount) / 2).round
       )
     end
 
@@ -79,7 +99,7 @@ RSpec.describe Map, type: :model do
       map.center_image
 
       expect(map.y).to eq(
-        ((map.original_height * map.zoom_amount) / 2).round
+        ((map.scaled_height * map.zoom_amount) / 2).round
       )
     end
   end

--- a/spec/system/manage_creatures_spec.rb
+++ b/spec/system/manage_creatures_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "manage creatures", type: :system do
   end
 
   it "can create a large creature token" do
-    base_token_size = 36
+    base_token_size = 40
     base_drawer_size = (base_token_size * 1.25).round
     large_map_size = (base_token_size * Token::SIZES["large"]).round
     user = create(:user)

--- a/spec/system/manage_maps_spec.rb
+++ b/spec/system/manage_maps_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "manage maps", type: :system do
     click_on "New Map"
     fill_in "Name", with: "Dwarven Excavation"
     attach_file "Image", file_fixture("dwarven-excavation.jpg")
+    fill_in "Grid size", with: "43"
     click_on "Create Map"
     expect(page).to have_content "Dwarven Excavation"
     find(".map-selector__option", text: "Dwarven Excavation").click
@@ -34,6 +35,7 @@ RSpec.describe "manage maps", type: :system do
       click_on "New Map"
       fill_in "Name", with: "Dwarven Excavation"
       attach_file "Image", file_fixture("dwarven-excavation.jpg")
+      fill_in "Grid size", with: "43"
       click_on "Create Map"
       expect(page).to have_content "Dwarven Excavation"
       find(".map-selector__option", text: "Dwarven Excavation").click


### PR DESCRIPTION
Normalizes maps to a grid size of 50px at `--zoom-scale: 1`.

First migration adds the column with a default of 43px to backfill our existing maps. Second removes the default.